### PR TITLE
fix a flaky test

### DIFF
--- a/src/main/java/eu/fayder/restcountries/v2/rest/CountryService.java
+++ b/src/main/java/eu/fayder/restcountries/v2/rest/CountryService.java
@@ -115,11 +115,16 @@ public class CountryService extends CountryServiceBase {
 
     public List<Country> getByRegionalBloc(String regionalBloc) {
         List<Country> result = new ArrayList<>();
-        for (Country country : countries) {
-            for (RegionalBloc countryRegionalBloc : country.getRegionalBlocs()) {
-                if (countryRegionalBloc.getAcronym().toUpperCase().equals(regionalBloc.toUpperCase())
-                        || countryRegionalBloc.getOtherAcronyms().contains(regionalBloc.toUpperCase())) {
-                    result.add(country);
+        if (countries != null && !countries.isEmpty()) {
+            for (Country country : countries) {
+                List<RegionalBloc> countryRegionalBlocs = country.getRegionalBlocs();
+                if (countryRegionalBlocs != null && !countryRegionalBlocs.isEmpty()) {
+                    for (RegionalBloc countryRegionalBloc : country.getRegionalBlocs()) {
+                        if (countryRegionalBloc.getAcronym().toUpperCase().equals(regionalBloc.toUpperCase())
+                                || countryRegionalBloc.getOtherAcronyms().contains(regionalBloc.toUpperCase())) {
+                            result.add(country);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description
Flaky tests are common occurrences in open-source projects, yielding inconsistent results—sometimes passing and sometimes failing—without code changes. NonDex is a tool for detecting and debugging wrong assumptions on under-determined Java APIs. I have resolved a flaky test issue using NonDex tool, specifically in the CountryServiceTest class located at `restcountries/src/main/java/eu/fayder/restcountries/v2/rest/CountryService.java`. 

### Root cause
The root cause of the flakiness was related to access an element in the countries List that is null while executing the getByRegionalBloc method in your test case. The test is failing because of a java.lang.NullPointerException that occurs when the code is unable to handle null properly. As a result, country.getRegionalBlocs() return a NULL list, it causes intermittent failures.

### Fix
This test has been resolved by checking for null or empty lists before iterating through them to ensure that countries is initialized and populated before attempting to iterate through it in the getByRegionalBloc method.

This fix is significant because it eliminates the uncertainty introduced by different output from country.getRegionalBlocs(), ensuring that the test consistently passes across different test runs. By doing so, we have improved the reliability and stability of our testing suite.

### How to test
Java: openjdk version "11.0.20.1"
Maven: Apache Maven 3.6.3
1. Compile the module
`mvn install -pl . -am -DskipTests`
2. Run regular tests
`mvn -pl . test -Dtest=eu.fayder.restcountries.v2.CountryServiceTest#getByRegionalBloc`
3. Run tests with NonDex tool
`mvn -pl . edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=eu.fayder.restcountries.v2.CountryServiceTest#getByRegionalBloc`
After fix, all tests pass